### PR TITLE
set ld_library_path via openshift_advanced_python_ld_library_path_element

### DIFF
--- a/usr/python/versions/2.7/lib/update-configuration
+++ b/usr/python/versions/2.7/lib/update-configuration
@@ -8,7 +8,7 @@ function update-configuration {
     echo "$OPENSHIFT_ADVANCED_PYTHON_DIR/virtenv/bin:$OPENSHIFT_ADVANCED_PYTHON_DIR/bin:${sclpath}" > $OPENSHIFT_ADVANCED_PYTHON_DIR/env/OPENSHIFT_PYTHON_PATH_ELEMENT
 
     local ld_path=$(LD_LIBRARY_PATH="" scl enable python27 "printenv LD_LIBRARY_PATH")
-    path_append ${LD_LIBRARY_PATH:-:} ${ld_path:-:} > $OPENSHIFT_ADVANCED_PYTHON_DIR/env/LD_LIBRARY_PATH
+    path_append ${LD_LIBRARY_PATH:-:} ${ld_path:-:} > $OPENSHIFT_ADVANCED_PYTHON_DIR/env/OPENSHIFT_ADVANCED_PYTHON_LD_LIBRARY_PATH_ELEMENT
 
     local man_path=$(MANPATH="" scl enable python27 "printenv MANPATH")
     path_append ${MANPATH:-:} ${man_path:-:} > $OPENSHIFT_ADVANCED_PYTHON_DIR/env/MANPATH

--- a/usr/python/versions/3.3/lib/update-configuration
+++ b/usr/python/versions/3.3/lib/update-configuration
@@ -8,7 +8,7 @@ function update-configuration {
     echo "$OPENSHIFT_ADVANCED_PYTHON_DIR/virtenv/venv/bin:$OPENSHIFT_ADVANCED_PYTHON_DIR/bin:${sclpath}" > $OPENSHIFT_ADVANCED_PYTHON_DIR/env/OPENSHIFT_PYTHON_PATH_ELEMENT
 
     local ld_path=$(LD_LIBRARY_PATH="" scl enable python33 "printenv LD_LIBRARY_PATH")
-    path_append ${LD_LIBRARY_PATH:-:} ${ld_path:-:} > $OPENSHIFT_ADVANCED_PYTHON_DIR/env/LD_LIBRARY_PATH
+    path_append ${LD_LIBRARY_PATH:-:} ${ld_path:-:} > $OPENSHIFT_ADVANCED_PYTHON_DIR/env/OPENSHIFT_ADVANCED_PYTHON_LD_LIBRARY_PATH_ELEMENT
 
     local man_path=$(MANPATH="" scl enable python33 "printenv MANPATH")
     path_append ${MANPATH:-:} ${man_path:-:} > $OPENSHIFT_ADVANCED_PYTHON_DIR/env/MANPATH


### PR DESCRIPTION
the ld_library_path env var was not being used, resulting in python not
being able to be used because of not being able to find the necessary
shared libraries. openshift 2 (online) uses the
`openshift_<cartname>_ld_library_path_element mechanism to merge all
cartridges' ld_library_path requests into the final ld_library_path
envvar. it appears to clobber this cart's attempts to set
ld_library_path directly. This PR fixes that clobber, and allows
python to be executed from with an ssh session without having to
manually set the ld_library_path

It follows the pattern of setting the ld_library_path in the [official python redhat cartridge](https://github.com/openshift/origin-server/blob/cacbbf91727201cec91f2398d363cdfb8519087e/cartridges/openshift-origin-cartridge-python/usr/versions/2.7-scl/lib/update-configuration#L13-L14).

Users can get this fix after patching without reinstalling the cartridge by running `./bin/control update-configuration`

closes #1
